### PR TITLE
Fixes and improvements for i18n support

### DIFF
--- a/lib/rails-timeago.rb
+++ b/lib/rails-timeago.rb
@@ -43,10 +43,15 @@ module Rails
     end
 
     def self.locale_file(locale)
+      locale_path + locale_file_name(locale)
+    end
+
+    def self.locale_file_name(locale)
+      # TODO: It should actually first check if the full locale name (e.g: nl-NL) exists, if it doesn't, then it should check shortname (e.g nl)
       locale = locale.to_s.downcase
       locale =~ /(\w+)\-(\w+)/
       locale = $1 unless $1.blank?
-      locale_path + 'jquery.timeago.' + locale + '.js'
+      'jquery.timeago.' + locale + '.js'
     end
 
     def self.has_locale_file(locale)

--- a/lib/rails-timeago/helper.rb
+++ b/lib/rails-timeago/helper.rb
@@ -59,7 +59,7 @@ module Rails
       # locale file for current locale.
       def timeago_script_tag
         if ::Rails::Timeago.has_locale_file(I18n.locale) and I18n.locale != :en
-          return javascript_include_tag 'locales/jquery.timeago.' + I18n.locale.to_s + '.js'
+          return javascript_include_tag 'locales/' + ::Rails::Timeago.locale_file_name(I18n.locale)
         end
         ''
       end


### PR DESCRIPTION
I've tried to tackle the following issues:
- has_locale_file checked statically for i18n.locale, instead of the locale parameter
- locale filenames used unprocessed i18n.locale name, which could be e.g "nl-NL", which failed because only "nl" locale exists

The latter issue is not entirely solved, because it now always cuts of the "-.." bit, while there are some jquery timeago locales that do have the country behind it.
For future improvements I would recommend first searching for the full name "nl-NL" and if not found, go for just "nl"
