### PR TITLE
When do not set Rails::Timeago.locales, it will not precompile locales

### DIFF
--- a/lib/rails-timeago.rb
+++ b/lib/rails-timeago.rb
@@ -21,7 +21,7 @@ module Rails
                   'locales/jquery.timeago.' + locale.to_s + '.js'
                 end
               end
-          elsif ::Rails::Timeago.locales.nil?
+          elsif ::Rails::Timeago.locales.empty?
             app.config.assets.precompile +=
               Dir[Rails::Timeago.locale_path + '*.js'].map do |f|
                 'locales/' + File.basename(f)


### PR DESCRIPTION
I see 

``` ruby
def self.locales
    @locales ||= []
end
```

`locales` will not be nil, then `elsif ::Rails::Timeago.locales.nil?` will never execute.

Btw, I found all spec is fail, it throw 

``` ruby
Rails::Timeago::Helper#timeago_tag should allow to override global options
     Failure/Error: @stub.timeago_tag(time, :format => :long).
     I18n::MissingTranslationData:
       translation missing: tlh.time.formats.long
     # ./lib/rails-timeago/helper.rb:42:in `timeago_tag'
     # ./spec/timeago/helper_spec.rb:78:in `block (3 levels) in <top (required)>'
```
