### PR TITLE
Run initializer on asset precompilation as well

### DIFF
--- a/lib/rails-timeago.rb
+++ b/lib/rails-timeago.rb
@@ -5,7 +5,7 @@ module Rails
   module Timeago
     if defined?(::Rails::Engine)
       class Engine < ::Rails::Engine # :nodoc:
-        initializer 'rails-timeago' do |app|
+        initializer 'rails-timeago', group: :all do |app|
           ActiveSupport.on_load(:action_controller) do
             include Rails::Timeago::Helper
           end


### PR DESCRIPTION
This seems to fix #4. The initializer will run when precompiling assets as well. All locale assets will be compiled by default. This can be limited by either setting `config.assets.locales = [...]` or `
config.assets.initialize_on_precompile = true` and `Rails::Timeago.locales = [...]` within a regular initializer file (which should happen anyway).
