### PR TITLE
Rails 4 Turbolinks

### DIFF
--- a/lib/assets/javascripts/rails-timeago.js
+++ b/lib/assets/javascripts/rails-timeago.js
@@ -3,25 +3,11 @@
 //
 //= require jquery.timeago
 
-var activate_timeago_timeout;
-
 jQuery(document).on('ready page:load', function() {
-  activate_timeago();
-});
-
-// Activate Timeago
-// Runs every minute and ensures that timeago is applied to each element only once.
-// Based on rmm5t's example on https://github.com/rmm5t/jquery-timeago/wiki/Tips
-function activate_timeago() { 
-  // Make sure this is the only timeout waiting to trigger
-  clearTimeout(activate_timeago_timeout);
-
   $('time[data-time-ago]').each(function() { 
     var $this = $(this); 
-    if ($this.data('active') != 'yes') { 
-      $this.timeago().data('active', 'yes');
+    if ($this.data('timeago-active') != 'true') { 
+      $this.timeago().data('timeago-active', 'true');
     }
   });
-
-  activate_timeago_timeout = setTimeout(activate_timeago, 60000);
-}
+});


### PR DESCRIPTION
New time elements that are created on the page after the page loads are not managed by timeago. Change `timeago()` call to fire when a new page is loaded via Turbolinks as well as on the initial page load event. 
