### PR TITLE
Support procs for :format argument

### DIFF
--- a/lib/rails-timeago/helper.rb
+++ b/lib/rails-timeago/helper.rb
@@ -39,6 +39,7 @@ module Rails
         time_options = time_options.merge html_options.extract!(*time_options.keys.select{|k| html_options.include?(k)})
         return time_options[:default] if time.nil?
 
+        time_options[:format] = time_options[:format].call(time, time_options) if time_options[:format].is_a?(Proc)
         if time_options[:title]
           html_options.merge! :title => time_options[:title].is_a?(Proc) ? time_options[:title].call(time, time_options) : time_options[:title]
         end

--- a/spec/timeago/helper_spec.rb
+++ b/spec/timeago/helper_spec.rb
@@ -23,6 +23,10 @@ describe Rails::Timeago::Helper do
       @stub.timeago_tag(time, :format => :short).should include("title=\"#{I18n.l time, :format => :short}\"")
     end
 
+    it 'should have human readable datetime as title attribute with given format' do
+      @stub.timeago_tag(time, :format => proc { |time, options| :long }).should include("title=\"#{I18n.l time, :format => :long}\"")
+    end
+
     it 'should have human readable datetime as title attribute with global format' do
       Rails::Timeago.default_options :format => :short
       @stub.timeago_tag(time).should include("title=\"#{I18n.l time, :format => :short}\"")
@@ -46,6 +50,11 @@ describe Rails::Timeago::Helper do
     it 'should have title attribute with proc value locally' do
       @stub.timeago_tag(time, :format => :long,
         :title => proc { |time, options| options[:format] }).should =~ /<time.*title="long".*>.*<\/time>/
+    end
+
+    it 'should have format attribute with proc value locally' do
+      @stub.timeago_tag(time,
+        :format => proc { |time, options| :long }).should include(">#{I18n.l time.to_date, :format => :long}<")
     end
 
     it 'should have data-time-ago attribute' do


### PR DESCRIPTION
Allows for formatting based on the date value.  Example:

``` ruby
:format => proc { |t, opts| t.year == Date.today.year ? :short : :long }
```
