### PR TITLE
Make inPast respect locale

### DIFF
--- a/vendor/assets/javascripts/jquery.timeago.js
+++ b/vendor/assets/javascripts/jquery.timeago.js
@@ -84,7 +84,7 @@
       }
 
       if(!this.settings.allowPast && distanceMillis >= 0) {
-        return this.settings.strings.inPast;
+        return this.settings.strings[lang].inPast;
       }
 
       var seconds = Math.abs(distanceMillis) / 1000;


### PR DESCRIPTION
`inPast` is being used on the root of `settings.string` rather than being scoped by `lang`. 
This fixes it so the text is properly localized.
