### PR TITLE
Remove an use of derpecated "ready" event (compatible with jQuery 3.0)

### DIFF
--- a/lib/assets/javascripts/rails-timeago.js
+++ b/lib/assets/javascripts/rails-timeago.js
@@ -4,7 +4,9 @@
 //= require jquery.timeago
 
 (function($) {
-	$(document).on('ready turbolinks:load page:load ajax:success', function() {
+	var fn = function() {
 		$('time[data-time-ago]').timeago();
-	});
+	};
+	$(fn);
+	$(document).on('turbolinks:load page:load ajax:success', fn);
 })(jQuery);


### PR DESCRIPTION
Since a synthetic event named "ready" has deprecated in jQuery 1.8 and removed in jQuery 3.0, replace with `$(fn)` instead.

https://jquery.com/upgrade-guide/3.0/#breaking-change-on-quot-ready-quot-fn-removed